### PR TITLE
Removed some radius options due to fee

### DIFF
--- a/app/views/shelters/index.html.erb
+++ b/app/views/shelters/index.html.erb
@@ -17,9 +17,6 @@
             <option value=""></option>
             <option value=1>1 Mile</option>
             <option value=5>5 Miles</option>
-            <option value=10>10 Miles</option>
-            <option value=25>25 Miles</option>
-            <option value=50>50 Miles</option>
           </select>
           <hr />
 


### PR DESCRIPTION
The fee for a zip code radius over 5 miles was $19/mo and is being removed for now. Choices of 1 and 5 miles are still available.
